### PR TITLE
Removed *.import from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,4 +12,3 @@ data_*/
 
 # Custom ignores
 .vs/
-*.import


### PR DESCRIPTION
Removed .import from .gitignore because these files should not be excluded.

From [this question](https://godotengine.org/qa/25950/what-doesnt-need-committed-version-control-in-godot-project):

> *.import files have the import flags used by the editor, needed to keep settings (like image filters, 3D scenes importing type, looping sounds, etc.

and

> .import files are auto-generated, but they can be customized. E.g. when you import a texture, you might want to disable filtering. This change is reflected in corresponding .import file, which might be auto-generated differently based on your default settings. So do commit .import files, but don't commit the .importdirectory.
