### PR TITLE
Ampliato il README e aggiunto COTRIBUTING.md 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributors guide lines.
+
+In un gioco si può lavorare in tante aree diverse: grafica, musica, scrittura, level design e programmazione. Se vuoi lavorare in una o più delle prime 4 aree, il miglior modo per iniziare è
+entrare in contatto con la community tramite i seguenti canali:
+
+- [Gruppo Telegram del progetto](https://t.me/joinchat/Fea7z0xQUHbZn0_wNyj6Vw)
+- [Gruppo Telegram Godot Italia](https://t.me/joinchat/Ga4KigwWn53t2RRfoaPSKg) 
+- [Discord server Godot Italia](https://discord.gg/7YuUqJB)
+
+Una volta dentro puoi subito far parte del team di sviluppo, saperne di più, proporre nuove idee e offrire il tuo lavoro.
+
+Se vuoi programmare o comunque apportare delle modifiche a questa repository, ci sono 2 modi.
+
+- 1. Come prima, entra a far parte della community e del team. Diventerai membro dell'organizzazione su GitHub per avere accesso alla repository. In questo modo potrai aggiungere modifiche alla repository, attraverso branches (modifiche dirette al master sono bloccate in ogni caso).
+- 2. Fai una fork di questa repository, aggiungi le tue modifiche e crea una pull request.
+
+Sono benvolute qualsiasi modifiche che aiuti il progetto, anche aggiustare una virgola in questo file
+è una pull request ben accetta. Anche se credi di avere poco da offrire, puoi comunque trovare
+qualcosa da fare con una community molto motivata. 
+
+## Linee guida programmazione
+
+Il gioco è programmato in gdscript e lo stile del codice da seguire (code conventions, naming conventions, whatever conventions) è quello proposto dal team di Godot stesso: [GDScript style guide](https://docs.godotengine.org/en/3.2/getting_started/scripting/gdscript/gdscript_styleguide.html).
+
+Inoltre è richiesta la [tipizzazione](https://docs.godotengine.org/en/3.2/getting_started/scripting/gdscript/gdscript_styleguide.html#static-typing). 
+
+Quando una pull request viene creata per integrare nuovo codice, prima di accettare il merge essa 
+deve passare almeno 1 review da parte di un altro membro. L'adesione alle linee guida è un fattore importante per avere una pull request accettata.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,10 @@ qualcosa da fare con una community molto motivata.
 
 Il gioco è programmato in gdscript e lo stile del codice da seguire (code conventions, naming conventions, whatever conventions) è quello proposto dal team di Godot stesso: [GDScript style guide](https://docs.godotengine.org/en/3.2/getting_started/scripting/gdscript/gdscript_styleguide.html).
 
-Inoltre è richiesta la [tipizzazione](https://docs.godotengine.org/en/3.2/getting_started/scripting/gdscript/gdscript_styleguide.html#static-typing). 
+Inoltre è richiesta la [tipizzazione](https://docs.godotengine.org/en/3.2/getting_started/scripting/gdscript/gdscript_styleguide.html#static-typing), e i signals vanno utilizzati esclusivamente via
+codice e non editor. Connettendo signals a metodi tramite l'editor rende complicato agli altri
+membri di sapere se esistono o cosa stanno facendo signal da te creati. Tramite codice invece è
+esplicito.
 
 Quando una pull request viene creata per integrare nuovo codice, prima di accettare il merge essa 
 deve passare almeno 1 review da parte di un altro membro. L'adesione alle linee guida è un fattore importante per avere una pull request accettata.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,12 +19,7 @@ qualcosa da fare con una community molto motivata.
 
 ## Linee guida programmazione
 
-Il gioco è programmato in gdscript e lo stile del codice da seguire (code conventions, naming conventions, whatever conventions) è quello proposto dal team di Godot stesso: [GDScript style guide](https://docs.godotengine.org/en/3.2/getting_started/scripting/gdscript/gdscript_styleguide.html).
-
-Inoltre è richiesta la [tipizzazione](https://docs.godotengine.org/en/3.2/getting_started/scripting/gdscript/gdscript_styleguide.html#static-typing), e i signals vanno utilizzati esclusivamente via
-codice e non editor. Connettendo signals a metodi tramite l'editor rende complicato agli altri
-membri di sapere se esistono o cosa stanno facendo signal da te creati. Tramite codice invece è
-esplicito.
+Il gioco è programmato in GDScript e lo stile del codice da seguire (code conventions, naming conventions, whatever conventions) è quello proposto dal team di Godot stesso: [GDScript style guide](https://docs.godotengine.org/en/3.2/getting_started/scripting/gdscript/gdscript_styleguide.html). In più è richiesta la [tipizzazione](https://docs.godotengine.org/en/3.2/getting_started/scripting/gdscript/gdscript_styleguide.html#static-typing).
 
 Quando una pull request viene creata per integrare nuovo codice, prima di accettare il merge essa 
 deve passare almeno 1 review da parte di un altro membro. L'adesione alle linee guida è un fattore importante per avere una pull request accettata.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,9 +10,8 @@ entrare in contatto con la community tramite i seguenti canali:
 Una volta dentro puoi subito far parte del team di sviluppo, saperne di più, proporre nuove idee e offrire il tuo lavoro.
 
 Se vuoi programmare o comunque apportare delle modifiche a questa repository, ci sono 2 modi.
-
-- 1. Come prima, entra a far parte della community e del team. Diventerai membro dell'organizzazione su GitHub per avere accesso alla repository. In questo modo potrai aggiungere modifiche alla repository, attraverso branches (modifiche dirette al master sono bloccate in ogni caso).
-- 2. Fai una fork di questa repository, aggiungi le tue modifiche e crea una pull request.
+  1. Come prima, entra a far parte della community e del team. Diventerai membro dell'organizzazione su GitHub per avere accesso alla repository. In questo modo potrai aggiungere modifiche alla repository, attraverso branches (modifiche dirette al master sono bloccate in ogni caso).
+  2. Fai una fork di questa repository, aggiungi le tue modifiche e crea una pull request.
 
 Sono benvolute qualsiasi modifiche che aiuti il progetto, anche aggiustare una virgola in questo file
 è una pull request ben accetta. Anche se credi di avere poco da offrire, puoi comunque trovare

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Lyskar
 Gioco open source della community italiana di Godot. [Sito web Godot Italia](https://godotengineitalia.com/).
 
-Open source Godot game from the Godot Italia community, [english version below](#english-readme).
+<!-- Open source Godot game from the Godot Italia community, [english version below](#english-readme). -->
 
 ## Il Gioco
 
@@ -15,7 +15,7 @@ con le proprie azioni.
 Il progetto è aperto a tutti e qualsiasi aiuto è il benvenuto.
 Se vuoi contribuire anche tu, inizia leggendo le linee guida che abbiamo scritto in [CONTRIBUTING.md](CONTRIBUTING.md).
 
-## English README
+<!-- ## English README
 
-TODO
+TODO -->
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Lyskar
-Gioco open source della community italiana di Godot.
+Gioco open source della community italiana di Godot. [Sito web Godot Italia](https://godotengineitalia.com/).
 
 Open source Godot game from the Godot Italia community, [english version below](#english-readme).
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # Lyskar
-Open source Godot game from the Godot Italia community.
+Gioco open source della community italiana di Godot.
+
+Open source Godot game from the Godot Italia community, [english version below](#english-readme).
+
+## Il Gioco
+
+Lyskar è un gioco story-driven con elementi fantasy e grafica 3D cartoonesca.
+Ha un sistema di magie innovativo e permette al giocatore di influenzare la storia e i personaggi
+con le proprie azioni. 
+
+
+## Vuoi partecipare anche tu?
+
+Il progetto è aperto a tutti e qualsiasi aiuto è il benvenuto.
+Se vuoi contribuire anche tu, inizia leggendo le linee guida che abbiamo scritto in [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## English README
+
+TODO
+


### PR DESCRIPTION
Scritta una primissima versione del readme con una sezione per i nuovi contributors che ha un link al file CONTRIBUTING.md.

CONTRIBUTING.md presenta i canali del team (telegram/discord) per iniziare a contribuire, e le linee guida da seguire (code style, tipizzazione, signals tramite codice).

Una possibile versione in inglese del readme puo' essere aggiunta in futuro.